### PR TITLE
fix issue for relative paths with folder progression

### DIFF
--- a/Source/Private/GetExclusions.ps1
+++ b/Source/Private/GetExclusions.ps1
@@ -11,18 +11,23 @@ function GetExclusions {
 
         # Normalize path
         $eObj.Path = $eObj.Path -replace '[\\\/]', [IO.Path]::DirectorySeparatorChar
-        
+
         if ($eObj.Path -match '^\..*') {
             # Path starts with '.', is relative. Replace with root folder
-            $BasePath = split-path (Resolve-Path $Excludelist).Path 
-            $eobj.Path = $eobj.Path -replace '^\.', $BasePath
+            $BasePath = split-path (Resolve-Path $Excludelist).Path
+            try {
+                $eobj.Path = Resolve-Path ($eobj.Path -replace '^\.', $BasePath) -ErrorAction Stop
+            }
+            catch {
+                Write-Warning "Failed to resolve path '$($eObj.Path)'. Exclusion will be skipped. $_"
+            }
         }
 
         if ([string]::IsNullOrEmpty($eObj.LineNumber) -and [string]::IsNullOrEmpty($eObj.Line)) {
             # Path or fileexclusion
             if ($eObj.Path -match '.*\\\*$') {
                 # Full path excluded
-                Get-ChildItem -Path $eObj.Path -Recurse -File -ErrorAction SilentlyContinue | ForEach-Object { 
+                Get-ChildItem -Path $eObj.Path -Recurse -File -ErrorAction SilentlyContinue | ForEach-Object {
                     $ExcludeResults.Add(@{
                         StringValue = $_.FullName
                         Type = 'File'


### PR DESCRIPTION
Fix for issue #34 .
This will resolve the relative path to remove any ".." and make sure it's the correct path when being compared.
I've added the write warning to make sure the script will continue and let the user know something went wrong with their exclusion list.